### PR TITLE
Change instructions to "dotnet build" if already in the corresponding…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Some notes and information about getting the back-end set up to develop the back
 2. Clone the vincesvideos repo to a desired path
 3. Go to Visual Studio Code, ensure you can use the terminal (view > terminal)
 4. Navigate to the directory
-5. From the root vincesvideos folder, attempt to build the api `dotnet build api` (or `dotnet build api`) if you're already in the api folder.
-From the root vincesvideos folder, attempt to build the api `dotnet build Api.Tests` (or `dotnet build Api.Tests`) if you're already in the api folder.
+5. From the root vincesvideos folder, attempt to build the api `dotnet build api` (or `dotnet build`) if you're already in the api folder.
+From the root vincesvideos folder, attempt to build the api `dotnet build Api.Tests` (or `dotnet build`) if you're already in the api folder.
 6. From the Api.Tests folder, attempt to run the unit tests `dotnet test Api.Tests` (or `dotnet test`) if you're already in the Api.Tests folder.
 7. Run the api project via `dotnet run -project api` or `dotnet run`
 8. Ensure swagger responds on the URL https://localhost:port/swagger (the port can be found in your visual studio code terminal)
 9. I have created some demo endpoints to test which will allow you to ensure everything is set up correctly. Try one of the demo urls https://localhost/Demo or https://localhost/Demo/5 (the number is arbitrary at the moment)
 
-Development Environment Configuration
-I've used Visual Studio Code to prevent from the bloat of Visual Studio
-A plugin named C# by Microsoft was added to Visual Studio Code to aid with intellisense and debugging
-You will very likely need a localhost dev certificate which is trusted to debug the webapi
+#### Development Environment Configuration
+* I've used Visual Studio Code to prevent from the bloat of Visual Studio
+* A plugin named C# by Microsoft was added to Visual Studio Code to aid with intellisense and debugging
+* You will very likely need a localhost dev certificate which is trusted to debug the webapi


### PR DESCRIPTION
Not sure if I'm right but noticed this when trying to set up backend, thanks!